### PR TITLE
Updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
+    - php: hhvm
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,10 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-escaper": "~2.5",
-        "zendframework/zend-validator": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-escaper": "^2.5",
+        "zendframework/zend-validator": "^2.5"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.5-dev",


### PR DESCRIPTION
- Use PHP 5.5+ **OR** 7.0
- Use `^` notation for all required dependencies.

I've tested against both the 2.5 and 2.6 series of zend-validator, and tests run perfectly in both cases, making this small tweak all that's necessary for it to be forwards-compatible.