### PR TITLE
Updated to php-coveralls/php-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ notifications:
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
@@ -59,4 +59,4 @@ after_success:
   - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi
 
 after_script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi


### PR DESCRIPTION
With version 2 package has been renamed from `satooshi/php-coveralls` to `php-coveralls/php-coveralls`, and the script has been renamed from `coveralls` to `php-coveralls`