### PR TITLE
fix phpdoc

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -682,7 +682,7 @@ class Uri implements UriInterface
      * You can check if a scheme is valid before setting it using the
      * validateScheme() method.
      *
-     * @param  string $scheme
+     * @param  string|null $scheme
      * @throws Exception\InvalidUriPartException
      * @return Uri
      */
@@ -703,7 +703,7 @@ class Uri implements UriInterface
     /**
      * Set the URI User-info part (usually user:password)
      *
-     * @param  string $userInfo
+     * @param  string|null $userInfo
      * @return Uri
      * @throws Exception\InvalidUriPartException If the schema definition
      * does not have this part
@@ -728,7 +728,7 @@ class Uri implements UriInterface
      * example the HTTP RFC clearly states that only IPv4 and valid DNS names
      * are allowed in HTTP URIs.
      *
-     * @param  string $host
+     * @param  string|null $host
      * @throws Exception\InvalidUriPartException
      * @return Uri
      */
@@ -752,7 +752,7 @@ class Uri implements UriInterface
     /**
      * Set the port part of the URI
      *
-     * @param  int $port
+     * @param  int|null $port
      * @return Uri
      */
     public function setPort($port)
@@ -764,7 +764,7 @@ class Uri implements UriInterface
     /**
      * Set the path
      *
-     * @param  string $path
+     * @param  string|null $path
      * @return Uri
      */
     public function setPath($path)
@@ -780,7 +780,7 @@ class Uri implements UriInterface
      * query string. Array values will be represented in the query string using
      * PHP's common square bracket notation.
      *
-     * @param  string|array $query
+     * @param  string|array|null $query
      * @return Uri
      */
     public function setQuery($query)
@@ -798,7 +798,7 @@ class Uri implements UriInterface
     /**
      * Set the URI fragment part
      *
-     * @param  string $fragment
+     * @param  string|null $fragment
      * @return Uri
      * @throws Exception\InvalidUriPartException If the schema definition
      * does not have this part

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -50,47 +50,47 @@ class Uri implements UriInterface
     /**
      * URI scheme
      *
-     * @var string
+     * @var string|null
      */
     protected $scheme;
 
     /**
      * URI userInfo part (usually user:password in HTTP URLs)
      *
-     * @var string
+     * @var string|null
      */
     protected $userInfo;
 
     /**
      * URI hostname
      *
-     * @var string
+     * @var string|null
      */
     protected $host;
 
     /**
      * URI port
      *
-     * @var int
+     * @var int|null
      */
     protected $port;
 
     /**
      * URI path
      *
-     * @var string
+     * @var string|null
      */
     protected $path;
 
     /**
      * URI query string
      *
-     * @var string
+     * @var string|null
      */
     protected $query;
 
     /**
-     * URI fragment
+     * URI fragment|null
      *
      * @var string
      */


### PR DESCRIPTION
setters also accept null but phpdoc defines that only string is allowed

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
