### PR TITLE
Fixed formatting in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- [#29](https://github.com/zendframework/zend-uri/pull/29) changes the behavior of `getHost()`: it will now always return a lowercase
-- representation. This is in accord with
-- [IETF 3986 Section 3.2.2](https://tools.ietf.org/html/rfc3986#section-3.2.2).
+- [#29](https://github.com/zendframework/zend-uri/pull/29) changes the behavior of `getHost()`:
+  it will now always return a lowercase representation. This is in accord with
+  [IETF 3986 Section 3.2.2](https://tools.ietf.org/html/rfc3986#section-3.2.2).
 
 ### Deprecated
 


### PR DESCRIPTION
Fixed formatting in CHANGELOG.md in 2.7.0 release.
Please update also release notes of that release: https://github.com/zendframework/zend-uri/releases/tag/release-2.7.0

![image](https://user-images.githubusercontent.com/7423207/53592990-64dbcf80-3b8f-11e9-9552-7ee57bc76dbb.png)