### PR TITLE
URI with ending colon without port

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -308,7 +308,7 @@ class Uri implements UriInterface
 
                 // If authority ends with colon, port will be empty string.
                 // Remove the colon from authority, but keeps port null
-                if ($port !== '') {
+                if ($port && $port !== '') {
                     $this->setPort((int) $port);
                 }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -308,7 +308,7 @@ class Uri implements UriInterface
 
                 // If authority ends with colon, port will be empty string.
                 // Remove the colon from authority, but keeps port null
-                if ($port && $port !== '') {
+                if ($port) {
                     $this->setPort((int) $port);
                 }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -312,7 +312,6 @@ class Uri implements UriInterface
                     $this->setPort((int) $port);
                 }
 
-                $this->setPort((int) $port);
                 $authority = substr($authority, 0, -$portLength);
             }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -301,10 +301,16 @@ class Uri implements UriInterface
                 $this->setUserInfo($userInfo);
             }
 
-            $nMatches = preg_match('/:[\d]{1,5}$/', $authority, $matches);
+            $nMatches = preg_match('/:[\d]{0,5}$/', $authority, $matches);
             if ($nMatches === 1) {
                 $portLength = strlen($matches[0]);
                 $port = substr($matches[0], 1);
+                
+                // If authority ends with colon, port will be empty string.
+                // Remove the colon from authority, but keeps port null
+                if($port !== ''){
+                    $this->setPort((int) $port);
+                }
 
                 $this->setPort((int) $port);
                 $authority = substr($authority, 0, -$portLength);

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -305,10 +305,10 @@ class Uri implements UriInterface
             if ($nMatches === 1) {
                 $portLength = strlen($matches[0]);
                 $port = substr($matches[0], 1);
-                
+
                 // If authority ends with colon, port will be empty string.
                 // Remove the colon from authority, but keeps port null
-                if($port !== ''){
+                if ($port !== '') {
                     $this->setPort((int) $port);
                 }
 

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -1377,7 +1377,7 @@ class UriTest extends TestCase
         $uriString = 'http://www.example.com:';
         $uri = new Uri($uriString);
 
-        $this->assertSame($uri->getHost(), 'www.example.com');
-        $this->assertSame($uri->getPort(), null);
+        $this->assertSame('www.example.com', $uri->getHost());
+        $this->assertSame(null, $uri->getPort());
     }
 }

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -1371,14 +1371,13 @@ class UriTest extends TestCase
             $uri->toString()
         );
     }
-        
+
     public function testUriWithEndingColonWithoutPort()
     {
         $uriString = 'http://www.example.com:';
         $uri = new Uri($uriString);
-        
+
         $this->assertSame($uri->getHost(), 'www.example.com');
         $this->assertSame($uri->getPort(), null);
-        
     }
 }

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -1378,6 +1378,6 @@ class UriTest extends TestCase
         $uri = new Uri($uriString);
 
         $this->assertSame('www.example.com', $uri->getHost());
-        $this->assertSame(null, $uri->getPort());
+        $this->assertNull($uri->getPort());
     }
 }

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -1371,4 +1371,14 @@ class UriTest extends TestCase
             $uri->toString()
         );
     }
+        
+    public function testUriWithEndingColonWithoutPort()
+    {
+        $uriString = 'http://www.example.com:';
+        $uri = new Uri($uriString);
+        
+        $this->assertSame($uri->getHost(), 'www.example.com');
+        $this->assertSame($uri->getPort(), null);
+        
+    }
 }


### PR DESCRIPTION
Based on issue #33 

**Previous behaviour**
```php
$sourceUri = "http://www.example.com:";
$uri = new \Zend\Uri\Http($sourceUri);

echo 'Scheme: '.$uri->getScheme().PHP_EOL;
echo 'Host: '.$uri->getHost().PHP_EOL;
echo 'Port: '.$uri->getPort().PHP_EOL;
echo 'Path: '.$uri->getPath().PHP_EOL;
```

Which gives the following result:
```
Scheme: http
Host: www.example.com:
Port: 
Path: /
```

**New behaviour**
With this fix, the new result will be:
```
Scheme: http
Host: www.example.com
Port: 
Path: /
```

which matches the result of `parse_url($uri)`.

I also added a new test for this case.

